### PR TITLE
WAL-77136: Solves an error when installing the plugin.

### DIFF
--- a/override/classes/Mail.php
+++ b/override/classes/Mail.php
@@ -20,6 +20,8 @@ require_once $modulePath . 'MailMessageEvent.php';
  *
  */
 class Mail extends MailCore{
+	// These lines prevents an error when copied by the system.
+	// @see ModuleCore::addOverride()
 
 	/**
 	 * Overrides the default send method. The method returns the number of successful recipients of the


### PR DESCRIPTION
When installing this plugin, an override is perform in the Main.php class. This override fails if there is empty line
between the class opener and the first method's docblock. This commit just adds a couple of lines that will be replaced by the system when doing the overwrite, and prevents the
syntax error to happen.